### PR TITLE
Add new location for Rust, also add Servo submodules

### DIFF
--- a/js/git-repos.json
+++ b/js/git-repos.json
@@ -1,6 +1,5 @@
 var mozGitRepos = [
-  ["rust", "mozilla/rust"],
-  ["servo", "mozilla/servo"],
+
   ["prospector", "mozilla/prospector"],
   ["collusion", "mozilla/collusion"],
   ["shumway", "mozilla/shumway"],
@@ -14,5 +13,46 @@ var mozGitRepos = [
   ["socorro","mozilla/socorro"],
   ["browserid","mozilla/browserid"],
   ["picl-idp","mozilla/picl-idp"],
-  ["zamboni","mozilla/zamboni"]
+  ["zamboni","mozilla/zamboni"],
+  
+  // Rust repos
+  ["rust", "mozilla-servo/rust"],
+  ["rust-www", "mozilla-servo/rust-www"],
+  ["rust-playpen", "mozilla-servo/rust-playpen"],
+  ["cargo", "mozilla-servo/cargo"],
+  ["rfcs", "mozilla-servo/rfcs"],
+
+  // Servo repos
+  ["servo", "mozilla/servo"], // Will later be moved to servo/servo 
+  ["rust-mozjs", "mozilla-servo/rust-mozjs"],
+  ["rust-cocoa", "mozilla-servo/rust-cocoa"],
+  ["rust-azure", "mozilla-servo/rust-azure"],
+  ["rust-harfbuzz", "mozilla-servo/rust-harfbuzz"],
+  ["rust-stb-image", "mozilla-servo/rust-stb-image"],
+  ["rust-opengles", "mozilla-servo/rust-opengles"],
+  ["rust-glut", "mozilla-servo/rust-glut"],
+  ["rust-geom", "mozilla-servo/rust-geom"],
+  ["rust-layers", "mozilla-servo/rust-layers"],
+  ["rust-http-client", "mozilla-servo/rust-http-client"],
+  ["rust-hubbub", "mozilla-servo/rust-hubbub"],
+  ["rust-core-foundation", "mozilla-servo/rust-core-foundation"],
+  ["rust-io-surface", "mozilla-servo/rust-io-surface"],
+  ["servo-viewer", "mozilla-servo/servo-viewer"],
+  ["rust-netsurfcss", "mozilla-servo/rust-netsurfcss"],
+  ["rust-wapcaplet", "mozilla-servo/rust-wapcaplet"],
+  ["rust-core-graphics", "mozilla-servo/rust-core-graphics"],
+  ["rust-core-text", "mozilla-servo/rust-core-text"],
+  ["rust-freetype", "mozilla-servo/rust-freetype"],
+  ["rust-cairo", "mozilla-servo/rust-cairo"],
+  ["rust-fontconfig", "mozilla-servo/rust-fontconfig"],
+  ["rust-xlib", "mozilla-servo/rust-xlib"],
+  ["rust-css", "mozilla-servo/rust-css"],
+  ["rust-alert", "mozilla-servo/rust-alert"],
+  ["rust-png", "mozilla-servo/rust-png"],
+  ["glfw-rs", "mozilla-servo/glfw-rs"],
+  ["rust-cssparser", "mozilla-servo/rust-cssparser"],
+  ["rust-egl", "mozilla-servo/rust-egl"],
+  ["servo-android-glue", "mozilla-servo/servo-android-glue"],
+  ["rust-phf", "mozilla-servo/rust-phf"],
+  ["string-cache", "mozilla-servo/string-cache"]
 ];


### PR DESCRIPTION
`mozilla/rust` was moved to [`rust-lang/rust`](github.com/rust-lang/rust) (along with the Rust playpen and related repos).

Additionally, a large amount of Servo code is in submodules kept in the mozilla-servo organization. Not all of these are maintained, by Mozilla, though (eg rust-http, rust-encoding — I haven't included these in the PR for that reason; they have upstreams and we just pull changes)
